### PR TITLE
add format_datetime method to format as ISO8601

### DIFF
--- a/t/07_format_datetime.t
+++ b/t/07_format_datetime.t
@@ -1,0 +1,78 @@
+
+use strict;
+use warnings;
+
+use lib qw( ./lib );
+
+use DateTime;
+use DateTime::Format::ISO8601;
+use Test::More tests => 5;
+
+my $dt = DateTime->new(
+    year => 2016,
+    month => 2,
+    day => 2,
+    hour => 5,
+    minute => 6,
+    second => 7,
+    time_zone => 'UTC',
+    formatter => 'DateTime::Format::ISO8601',
+);
+
+is "$dt", '2016-02-02T05:06:07Z', 'default format in UTC';
+
+$dt = DateTime->new(
+    year => 2016,
+    month => 2,
+    day => 2,
+    hour => 5,
+    minute => 6,
+    second => 7,
+    time_zone => 'America/Chicago',
+    formatter => 'DateTime::Format::ISO8601',
+);
+
+is "$dt", '2016-02-02T05:06:07-06:00', 'default format in America/Chicago DST';
+
+$dt = DateTime->new(
+    year => 2016,
+    month => 2,
+    day => 2,
+    hour => 5,
+    minute => 6,
+    second => 7,
+    nanosecond => 123,
+    time_zone => 'America/Chicago',
+    formatter => 'DateTime::Format::ISO8601',
+);
+
+is "$dt", '2016-02-02T05:06:07.000000123-06:00', 'default format with nanoseconds in America/Chicago DST';
+
+$dt = DateTime->new(
+    year => 2016,
+    month => 2,
+    day => 2,
+    hour => 5,
+    minute => 6,
+    second => 7,
+    nanosecond => 123000000,
+    time_zone => 'America/Chicago',
+    formatter => 'DateTime::Format::ISO8601',
+);
+
+is "$dt", '2016-02-02T05:06:07.123-06:00', 'default format with milliseconds in America/Chicago DST';
+
+$dt = DateTime->new(
+    year => 2016,
+    month => 2,
+    day => 2,
+    hour => 5,
+    minute => 6,
+    second => 7,
+    time_zone => 'UTC',
+);
+
+is +DateTime::Format::ISO8601->format_datetime( $dt ),
+    '2016-02-02T05:06:07Z',
+    'default format in UTC, called as class method';
+


### PR DESCRIPTION
The format_datetime method is called automatically by DateTime.pm when
setting the "formatter" class. The formatter in this class formats the
date/time as a valid, full ISO8601 datetime.

This makes it a bit easier to get a DateTime object that will automatically stringify to a full ISO8601 date/time string. See https://github.com/houseabsolute/DateTime.pm/pull/5