### PR TITLE
add support for YYYY-MM-DDThh:mm:ss.ss[+-]hh

### DIFF
--- a/lib/DateTime/Format/ISO8601.pm
+++ b/lib/DateTime/Format/ISO8601.pm
@@ -687,6 +687,28 @@ DateTime::Format::Builder->create_class(
                 ],
             },
             {
+                #YYYY-MM-DDThh:mm:ss.ss[+-]hh 1985-04-12T10:15:30.5+01 1985-04-12T10:15:30.5-05
+                regex  => qr/^ (\d{4}) -  (\d\d) - (\d\d)
+                            T?? (\d\d) : (\d\d) : (\d\d) [\.,] (\d+)
+                            ([+-] \d\d ) $/x,
+                params => [ qw( year month day hour minute second nanosecond time_zone ) ],
+                postprocess => [
+                    \&_fractional_second,
+                    \&_normalize_offset,
+                ],
+            },
+            {
+                #YYYYMMDDThhmmss.ss[+-]hh 19850412T101530.5+01 20041020T101530.5-05
+                regex  => qr/^ (\d{4}) (\d\d) (\d\d)
+                            T?? (\d\d) (\d\d) (\d\d) [\.,] (\d+)
+                            ([+-] \d\d ) $/x,
+                params => [ qw( year month day hour minute second nanosecond time_zone ) ],
+                postprocess => [
+                    \&_fractional_second,
+                    \&_normalize_offset,
+                ],
+            },
+            {
                 #YYYY-MM-DDThh:mm:ss.ss[+-]hh:mm 1985-04-12T10:15:30.5+01:00 1985-04-12T10:15:30.5-05:00
                 regex  => qr/^ (\d{4}) -  (\d\d) - (\d\d)
                             T?? (\d\d) : (\d\d) : (\d\d) [\.,] (\d+)
@@ -1323,6 +1345,8 @@ optionally prefixed with 'T'
 
    YYYYMMDDThhmmss.ss
    YYYY-MM-DDThh:mm:ss.ss
+   YYYYMMDDThhmmss.ss[+-]hh
+   YYYY-MM-DDThh:mm:ss.ss[+-]hh
    YYYYMMDDThhmmss.ss[+-]hhmm
    YYYY-MM-DDThh:mm:ss.ss[+-]hh:mm
 

--- a/t/02_examples.t
+++ b/t/02_examples.t
@@ -7,7 +7,7 @@ use warnings;
 
 use lib qw( ./lib );
 
-use Test::More tests => 175;
+use Test::More tests => 181;
 
 use DateTime::Format::ISO8601;
 
@@ -606,6 +606,22 @@ my $iso8601 = DateTime::Format::ISO8601->new(
     #YYYY-MM-DDThh:mm:ss+hh:mm 1985-04-12T10:15:30+04:00
     my $dt = $iso8601->parse_datetime( '1985-04-12T10:15:30+04:00' );
     is( $dt->iso8601, '1985-04-12T10:15:30' );
+    is( $dt->time_zone->name, '+0400' );
+}
+
+{
+    #YYYY-MM-DDThh:mm:ss.ss+hh 1985-04-12T10:15:30.5+04
+    my $dt = $iso8601->parse_datetime( '1985-04-12T10:15:30.5+04' );
+    is( $dt->iso8601, '1985-04-12T10:15:30' );
+    is( $dt->nanosecond, 500_000_000 );
+    is( $dt->time_zone->name, '+0400' );
+}
+
+{
+    #YYYYMMDDThhmmss.ss+hh 19850412T101530.5+04
+    my $dt = $iso8601->parse_datetime( '19850412T101530.5+04' );
+    is( $dt->iso8601, '1985-04-12T10:15:30' );
+    is( $dt->nanosecond, 500_000_000 );
     is( $dt->time_zone->name, '+0400' );
 }
 


### PR DESCRIPTION
 and YYYYMMDDThhmmss.ss[+-]hh

i.e. with fractional seconds and an hour-only timezone offset

As discussed in https://rt.cpan.org/Ticket/Display.html?id=130682